### PR TITLE
check for @mentions in text which violates Twitter API T&Cs

### DIFF
--- a/photobooth.py
+++ b/photobooth.py
@@ -89,24 +89,29 @@ while True:
     photos = capture_photos(4)
     if twitter:
         logger.info("twitter enabled")
-        camera.annotate_text = text['tweeting with cancel']
-        pressed = button.wait_for_press(timeout=3)
-        if pressed:
-            logger.info("button pressed - not tweeting")
+        if "@" in text['tweet']:
+            logger.info("@mention in text violates Twitter T&Cs (see spamming) - not tweeting")
             camera.annotate_text = text['not tweeting']
-            button.wait_for_release()
             sleep(2)
         else:
-            logger.info("button not pressed - tweeting")
-            camera.annotate_text = text['tweeting']
-            try:
-                uploaded_photos = upload_photos(photos)
-                tweet_photos(text['tweet'], uploaded_photos)
-                sleep(1)
-            except:
-                logger.info("failed to tweet")
-                camera.annotate_text = text['failed tweet']
+            camera.annotate_text = text['tweeting with cancel']
+            pressed = button.wait_for_press(timeout=3)
+            if pressed:
+                logger.info("button pressed - not tweeting")
+                camera.annotate_text = text['not tweeting']
+                button.wait_for_release()
                 sleep(2)
+            else:
+                logger.info("button not pressed - tweeting")
+                camera.annotate_text = text['tweeting']
+                try:
+                    uploaded_photos = upload_photos(photos)
+                    tweet_photos(text['tweet'], uploaded_photos)
+                    sleep(1)
+                except:
+                    logger.info("failed to tweet")
+                    camera.annotate_text = text['failed tweet']
+                    sleep(2)
     else:
         logger.info("twitter disabled")
     camera.annotate_text = None


### PR DESCRIPTION
Sending repeat @mentions is prohibited by the Twitter Rules: 

Spam: You may not use the Twitter service for the purpose of spamming anyone. What constitutes “spamming” will evolve as we respond to new tricks and tactics by spammers. Some of the factors that we take into account when determining what conduct is considered to be spamming are:

    if you send large numbers of unsolicited replies or mentions;
    if you send large numbers of duplicate replies or mentions;

Note that this behavior is not allowed regardless of whether or not it is automated. Per the Automation Rules if you are sending automated @mentions the recipient or mentioned user(s) must have requested or have clearly indicated an intent on Twitter  to be contacted by you.